### PR TITLE
feat: add `/recovery/guardian` integration

### DIFF
--- a/packages/auth-server/composables/useRecoveryGuardian.ts
+++ b/packages/auth-server/composables/useRecoveryGuardian.ts
@@ -1,0 +1,1 @@
+export const useRecoveryGuardian = () => {};

--- a/packages/auth-server/composables/useValidateAccount.ts
+++ b/packages/auth-server/composables/useValidateAccount.ts
@@ -1,0 +1,46 @@
+import type { Address } from "viem";
+import { ref } from "vue";
+
+import { useClientStore } from "~/stores/client";
+
+export function useValidateAccount() {
+  const { getPublicClient, defaultChain } = useClientStore();
+  const runtimeConfig = useRuntimeConfig();
+
+  const isValidatingAccount = ref(false);
+  const error = ref<Error | null>(null);
+
+  const validateAccount = async (address: Address): Promise<boolean> => {
+    isValidatingAccount.value = true;
+    error.value = null;
+
+    try {
+      const publicClient = getPublicClient({ chainId: defaultChain.id });
+
+      const isSSO = await publicClient.readContract({
+        address,
+        abi: [{
+          type: "function",
+          name: "supportsInterface",
+          inputs: [{ type: "bytes4", name: "interfaceId" }],
+          outputs: [{ type: "bool" }],
+          stateMutability: "view",
+        }],
+        functionName: "supportsInterface",
+        args: [runtimeConfig.public.ssoAccountInterfaceId as Address],
+      });
+      return isSSO;
+    } catch (err) {
+      error.value = err as Error;
+      return false;
+    } finally {
+      isValidatingAccount.value = false;
+    }
+  };
+
+  return {
+    validateAccount,
+    isValidatingAccount,
+    error,
+  };
+}

--- a/packages/auth-server/nuxt.config.ts
+++ b/packages/auth-server/nuxt.config.ts
@@ -72,6 +72,7 @@ export default defineNuxtConfig({
         nftQuestAddress: "0x4D533d3B20b50b57268f189F93bFaf8B39c36AB6",
       },
       appUrl: process.env.NUXT_PUBLIC_APP_URL || "https://auth-test.zksync.dev",
+      ssoAccountInterfaceId: "0xb9094997",
     },
   },
 });

--- a/packages/auth-server/pages/recovery/guardian/index.vue
+++ b/packages/auth-server/pages/recovery/guardian/index.vue
@@ -118,7 +118,7 @@ const validateAddress = async () => {
     addressError.value = "The address is not a valid ZKsync SSO account";
     isValidAddress.value = false;
 
-    // At this point we deliberately ignore errors coming form
+    // At this point we deliberately ignore errors coming from
     // account validation, as they could stem from erc-165 not being
     // supported by the input address.
     return;

--- a/packages/auth-server/pages/recovery/guardian/index.vue
+++ b/packages/auth-server/pages/recovery/guardian/index.vue
@@ -45,7 +45,8 @@
 
           <ZkButton
             class="w-full"
-            :disabled="!isValidAddress"
+            :disabled="!isValidAddress || isValidatingAccount"
+            :loading="isValidatingAccount"
             @click="handleContinue"
           >
             Continue
@@ -71,6 +72,7 @@
 import { ref } from "vue";
 import type { RegisterNewPasskeyReturnType } from "zksync-sso/client/passkey";
 
+import { useValidateAccount } from "~/composables/useValidateAccount";
 import { AddressSchema } from "~/utils/schemas";
 
 definePageMeta({
@@ -84,6 +86,7 @@ const isValidAddress = ref(false);
 const newPasskey = ref<RegisterNewPasskeyReturnType | null>(null);
 
 const { inProgress: registerInProgress } = usePasskeyRegister();
+const { validateAccount, isValidatingAccount } = useValidateAccount();
 
 const stepTitle = computed(() => {
   switch (currentStep.value) {
@@ -98,15 +101,31 @@ const stepTitle = computed(() => {
   }
 });
 
-const validateAddress = () => {
+const validateAddress = async () => {
   const result = AddressSchema.safeParse(address.value);
-  if (result.success) {
-    addressError.value = "";
-    isValidAddress.value = true;
-  } else {
+  if (!result.success) {
     addressError.value = "Not a valid address";
     isValidAddress.value = false;
+    return;
   }
+
+  // Reset errors without enabling the Continue button just yet
+  addressError.value = "";
+  isValidAddress.value = false;
+
+  const isValid = await validateAccount(result.data);
+  if (!isValid) {
+    addressError.value = "The address is not a valid ZKsync SSO account";
+    isValidAddress.value = false;
+
+    // At this point we deliberately ignore errors coming form
+    // account validation, as they could stem from erc-165 not being
+    // supported by the input address.
+    return;
+  }
+
+  addressError.value = "";
+  isValidAddress.value = true;
 };
 
 const handleContinue = () => {


### PR DESCRIPTION
# Description
Add `/recovery/guardian` integration, that:
- Verify the input address is a ZKsync SSO account

